### PR TITLE
Change .(un)bind to .on/.off

### DIFF
--- a/guiders.js
+++ b/guiders.js
@@ -17,7 +17,7 @@
 
 var guiders = (function($) {
   var guiders = $.guiders = {};
-  
+
   guiders.version = "2.0.0";
 
   guiders._defaultSettings = {
@@ -35,7 +35,7 @@ var guiders = (function($) {
       top: null,
       left: null
     },
-    onClose: null, 
+    onClose: null,
     onHide: null,
     onShow: null,
     overlay: false,
@@ -87,20 +87,20 @@ var guiders = (function($) {
     "leftTop": 10
   };
   guiders._windowHeight = 0;
-  
+
   // Basic IE browser detection
   var ieBrowserMatch = navigator.userAgent.match(/MSIE\s([\d.]+)/);
   guiders._isIE = ieBrowserMatch && ieBrowserMatch.length > 1;
   guiders._ieVersion = ieBrowserMatch && ieBrowserMatch.length > 1 ? Number(ieBrowserMatch[1]) : -1;
-  
+
   guiders._addButtons = function(myGuider) {
     var guiderButtonsContainer = myGuider.elem.find(".guiders_buttons_container");
-  
+
     if (myGuider.buttons === null || myGuider.buttons.length === 0) {
       guiderButtonsContainer.remove();
       return;
     }
-  
+
     for (var i = myGuider.buttons.length - 1; i >= 0; i--) {
       var thisButton = myGuider.buttons[i];
       var thisButtonElem = $(guiders._buttonElement,
@@ -110,16 +110,16 @@ var guiders = (function($) {
       if (typeof thisButton.classString !== "undefined" && thisButton.classString !== null) {
         thisButtonElem.addClass(thisButton.classString);
       }
-  
+
       guiderButtonsContainer.append(thisButtonElem);
-      
+
       var thisButtonName = thisButton.name.toLowerCase();
       if (thisButton.onclick) {
-        thisButtonElem.bind(guiders._buttonClickEvent, thisButton.onclick);
+        thisButtonElem.on(guiders._buttonClickEvent, thisButton.onclick);
       } else {
         switch (thisButtonName) {
           case guiders._closeButtonTitle.toLowerCase():
-            thisButtonElem.bind(guiders._buttonClickEvent, function () {
+            thisButtonElem.on(guiders._buttonClickEvent, function () {
               guiders.hideAll();
               if (myGuider.onClose) {
                 myGuider.onClose(myGuider, false /* close by button */);
@@ -128,24 +128,24 @@ var guiders = (function($) {
             });
             break;
           case guiders._nextButtonTitle.toLowerCase():
-            thisButtonElem.bind(guiders._buttonClickEvent, function () {
+            thisButtonElem.on(guiders._buttonClickEvent, function () {
               !myGuider.elem.data("locked") && guiders.next();
             });
             break;
           case guiders._backButtonTitle.toLowerCase():
-            thisButtonElem.bind(guiders._buttonClickEvent, function () {
+            thisButtonElem.on(guiders._buttonClickEvent, function () {
               !myGuider.elem.data("locked") && guiders.prev();
             });
             break;
         }
       }
     }
-  
+
     if (myGuider.buttonCustomHTML !== "") {
       var myCustomHTML = $(myGuider.buttonCustomHTML);
       myGuider.elem.find(".guiders_buttons_container").append(myCustomHTML);
     }
-  
+
     if (myGuider.buttons.length === 0) {
       guiderButtonsContainer.remove();
     }
@@ -166,12 +166,12 @@ var guiders = (function($) {
        $("body").trigger("guidersClose");
     });
   };
-  
+
   guiders._attach = function(myGuider) {
     if (typeof myGuider !== 'object') {
       return;
     }
-        
+
     var attachTo = $(myGuider.attachTo);
 
     var myHeight = myGuider.elem.innerHeight();
@@ -187,12 +187,12 @@ var guiders = (function($) {
       myGuider.elem.css("left", ($(window).width() - myWidth) / 2 + "px");
       return;
     }
-    
+
     // Otherwise, the guider is positioned relative to the attachTo element.
     var base = attachTo.offset();
     var top = base.top;
     var left = base.left;
-    
+
     // topMarginOfBody corrects positioning if body has a top margin set on it.
     var topMarginOfBody = $("body").outerHeight(true) - $("body").outerHeight(false);
     top -= topMarginOfBody;
@@ -203,11 +203,11 @@ var guiders = (function($) {
       // As an alternative to the clock model, you can also use keywords to position the guider.
       myGuider.position = guiders._offsetNameMapping[myGuider.position];
     }
-    
+
     var attachToHeight = attachTo.innerHeight();
-    var attachToWidth = attachTo.innerWidth();  
+    var attachToWidth = attachTo.innerWidth();
     var bufferOffset = 0.9 * guiders._arrowSize;
-    
+
     // offsetMap follows the form: [height, width]
     var offsetMap = {
       1: [-bufferOffset - myHeight, attachToWidth - myWidth],
@@ -223,11 +223,11 @@ var guiders = (function($) {
       11: [-bufferOffset - myHeight, 0],
       12: [-bufferOffset - myHeight, attachToWidth/2 - myWidth/2]
     };
-    
+
     var offset = offsetMap[myGuider.position];
     top += offset[0];
     left += offset[1];
-    
+
     var positionType = "absolute";
     // If the element you are attaching to is position: fixed, then we will make the guider
     // position: fixed as well.
@@ -236,7 +236,7 @@ var guiders = (function($) {
       top -= $(window).scrollTop();
       left -= $(window).scrollLeft();
     }
-    
+
     // If you specify an additional offset parameter when you create the guider, it gets added here.
     if (myGuider.offset.top !== null) {
       top += myGuider.offset.top;
@@ -244,23 +244,23 @@ var guiders = (function($) {
     if (myGuider.offset.left !== null) {
       left += myGuider.offset.left;
     }
-    
+
     guiders._styleArrow(myGuider);
-    
+
     // Finally, set the style of the guider and return it!
     myGuider.elem.css({
       "position": positionType,
       "top": top,
       "left": left
     });
-    
+
     return myGuider;
   };
 
   guiders._dehighlightElement = function(selector) {
     $(selector).removeClass('guiders_highlight');
   };
-  
+
   guiders._hideOverlay = function() {
     $("#guiders_overlay").fadeOut("fast");
   };
@@ -310,7 +310,7 @@ var guiders = (function($) {
       12: "guiders_arrow_down"
     };
     myGuiderArrow.addClass(newClass[position]);
-  
+
     var myHeight = myGuider.elem.innerHeight();
     var myWidth = myGuider.elem.innerWidth();
     var arrowOffset = guiders._arrowSize / 2;
@@ -352,7 +352,7 @@ var guiders = (function($) {
       }
     }
   };
-  
+
   guiders._updatePositionOnResize = function() {
     // Change the bubble position after browser gets resized
     var _resizing = undefined;
@@ -371,7 +371,7 @@ var guiders = (function($) {
   guiders._updatePositionOnResize();
 
   guiders._unwireEscape = function (myGuider) {
-    $(document).unbind("keydown");
+    $(document).off("keydown");
   };
 
   guiders._wireEscape = function (myGuider) {
@@ -384,18 +384,18 @@ var guiders = (function($) {
         $("body").trigger("guidersClose");
         return false;
       }
-    });      
+    });
   };
 
   guiders.createGuider = function(passedSettings) {
     if (passedSettings === null || passedSettings === undefined) {
       passedSettings = {};
     }
-    
+
     // Extend those settings with passedSettings
     myGuider = $.extend({}, guiders._defaultSettings, passedSettings);
     myGuider.id = myGuider.id || "guider_random_" + String(Math.floor(Math.random() * 1000));
-    
+
     var guiderElement = $("#" + myGuider.id);
     if (!guiderElement.length) {
       // If the guider already exists in the DOM, use that, as an alternate guider instantiation method.
@@ -403,12 +403,12 @@ var guiders = (function($) {
       // Otherwise, use the html skeleton.
       guiderElement = $(guiders._htmlSkeleton);
     }
-    
+
     myGuider.elem = guiderElement;
     if (typeof myGuider.classString !== "undefined" && myGuider.classString !== null) {
       myGuider.elem.addClass(myGuider.classString);
     }
-    
+
     // You may pass a parameter to width/maxwidth as either a string or a number.
     // If it's a number then it is assumed to be in px.
     if (Number(myGuider.width) === myGuider.width) {
@@ -419,35 +419,35 @@ var guiders = (function($) {
     }
     myGuider.elem.css("width", myGuider.width);
     myGuider.elem.css("maxWidth", myGuider.maxWidth);
-    
+
     var guiderTitleContainer = guiderElement.find(".guiders_title");
     guiderTitleContainer.html(myGuider.title);
-    
+
     guiderElement.find(".guiders_description").html(myGuider.description);
-    
+
     guiders._addButtons(myGuider);
-    
+
     if (myGuider.xButton) {
         guiders._addXButton(myGuider);
     }
-    
+
     guiderElement.hide();
     guiderElement.appendTo("body");
     guiderElement.attr("id", myGuider.id);
-    
+
     // Ensure myGuider.attachTo is a jQuery element.
     if (typeof myGuider.attachTo !== "undefined" && myGuider !== null) {
       guiders._attach(myGuider);
     }
-    
+
     guiders._initializeOverlay();
-    
+
     guiders._guiders[myGuider.id] = myGuider;
     if (guiders._lastCreatedGuiderID != null) {
       myGuider.prev = guiders._lastCreatedGuiderID;
     }
     guiders._lastCreatedGuiderID = myGuider.id;
-    
+
     /**
      * If the URL of the current window is of the form
      * http://www.myurl.com/mypage.html#guider=id
@@ -456,17 +456,17 @@ var guiders = (function($) {
     if (myGuider.isHashable) {
       guiders._showIfHashed(myGuider);
     }
-    
+
     return guiders;
   };
-  
+
   guiders.get = function(id) {
     if (typeof guiders._guiders[id] === "undefined") {
       return null;
     }
     return guiders._guiders[id] || null;
   };
-  
+
   guiders.getCurrentGuider = function() {
     return guiders._guiders[guiders._currentGuiderID] || null;
   };
@@ -492,7 +492,7 @@ var guiders = (function($) {
     }
     return guiders;
   };
-  
+
   guiders.next = function() {
     var currentGuider = guiders._guiders[guiders._currentGuiderID];
     if (typeof currentGuider === "undefined") {
@@ -520,7 +520,7 @@ var guiders = (function($) {
       }
     }
   };
-  
+
   guiders.prev = function () {
     var currentGuider = guiders._guiders[guiders._currentGuiderID];
     if (typeof currentGuider === "undefined") {
@@ -531,10 +531,10 @@ var guiders = (function($) {
       // no previous to look at
       return null;
     }
-  
+
     var prevGuider = guiders._guiders[currentGuider.prev];
     prevGuider.elem.data("locked", true);
-    
+
     // Note we use prevGuider.id as "prevGuider" is _already_ looking at the previous guider
     var prevGuiderId = prevGuider.id || null;
     if (prevGuiderId !== null && prevGuiderId !== "") {
@@ -548,7 +548,7 @@ var guiders = (function($) {
       return myGuider;
     }
   };
-  
+
   guiders.reposition = function() {
     var currentGuider = guiders._guiders[guiders._currentGuiderID];
     guiders._attach(currentGuider);
@@ -559,12 +559,12 @@ var guiders = (function($) {
     if (typeof currentGuider === "undefined") {
       return;
     }
-    
+
     var windowHeight = guiders._windowHeight;
     var scrollHeight = $(window).scrollTop();
     var guiderOffset = currentGuider.elem.offset();
     var guiderElemHeight = currentGuider.elem.height();
-    
+
     // Scroll to the guider's position.
     var scrollToHeight = Math.round(Math.max(guiderOffset.top + (guiderElemHeight / 2) - (windowHeight / 2), 0));
     window.scrollTo(0, scrollToHeight);
@@ -574,7 +574,7 @@ var guiders = (function($) {
     if (!id && guiders._lastCreatedGuiderID) {
       id = guiders._lastCreatedGuiderID;
     }
-  
+
     var myGuider = guiders.get(id);
     if (myGuider.overlay) {
       guiders._showOverlay(myGuider);
@@ -583,41 +583,41 @@ var guiders = (function($) {
         guiders._highlightElement(myGuider.attachTo);
       }
     }
-    
+
     if (myGuider.closeOnEscape) {
       guiders._wireEscape(myGuider);
     } else {
       guiders._unwireEscape(myGuider);
     }
-  
+
     // You can use an onShow function to take some action before the guider is shown.
     if (myGuider.onShow) {
       myGuider.onShow(myGuider);
     }
     guiders._attach(myGuider);
     myGuider.elem.fadeIn("fast").data("locked", false);
-      
+
     guiders._currentGuiderID = id;
-    
+
     var windowHeight = guiders._windowHeight = $(window).height();
     var scrollHeight = $(window).scrollTop();
     var guiderOffset = myGuider.elem.offset();
     var guiderElemHeight = myGuider.elem.height();
-    
+
     var isGuiderBelow = (scrollHeight + windowHeight < guiderOffset.top + guiderElemHeight); /* we will need to scroll down */
     var isGuiderAbove = (guiderOffset.top < scrollHeight); /* we will need to scroll up */
-    
+
     if (myGuider.autoFocus && (isGuiderBelow || isGuiderAbove)) {
       // Sometimes the browser won't scroll if the person just clicked,
       // so let's do this in a setTimeout.
       setTimeout(guiders.scrollToCurrent, 10);
     }
-    
+
     $(myGuider.elem).trigger("guiders.show");
 
     return guiders;
   };
-  
+
   // Allow separate method of instantiating guiders, with $("#guider2").guider()
   // You can pass parameters to the guiders with either data-attributes on the element,
   // or as optional parameters in the options hash: $("#guider").guider(options)
@@ -625,7 +625,7 @@ var guiders = (function($) {
     passedOptions = passedOptions || {};
     var options = $.extend({}, passedOptions);
     options.id = $(this).attr("id");
-      
+
     var buttons = [];
     $(this).find(".guiders_buttons_container").children().each(function () {
       var buttonOptions = {
@@ -640,7 +640,7 @@ var guiders = (function($) {
       buttons.push(buttonOptions);
     });
     options.buttons = buttons;
-    
+
     title = $(this).find(".guiders_title").html()
     if (title) {
       options.title = title;
@@ -650,29 +650,29 @@ var guiders = (function($) {
     if (description) {
       options.description = description;
     }
-    
+
     for (var optionName in guiders._defaultSettings) {
       if (!guiders._defaultSettings.hasOwnProperty(optionName)) {
         continue;
       }
-    
+
       var optionValue = $(this).attr("data-" + optionName);
       if (optionValue === undefined || optionValue === null) {
         continue;
       }
-    
+
       if (optionValue == "true") {
         optionValue = true;
       } else if (optionValue == "false") {
         optionValue = false;
       }
-    
+
       options[optionName] = optionValue;
     }
-    
+
     guiders.createGuider(options);
     return this;
 	};
-	  
+
   return guiders;
 }).call(this, jQuery);


### PR DESCRIPTION
`.bind` and `.unbind` are deprecated in jQuery 3, and they exist since jQuery 1.7 (this lib required version). So I believe this is harmless update.

[?w=1](https://github.com/BrandwatchLtd/Guiders-JS/pull/1/files?w=1) is your friend, since there was a lot of trailing whitespace in the file :)
